### PR TITLE
Make the ingredient list in the order they are mentioned

### DIFF
--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -8,6 +8,7 @@ description = "A parser written in Rust for CookLang"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+indexmap = {version = "1.8.0", features = ["serde"]}
 pest = "2.1.3"
 pest_derive = "2.1.0"
 serde = {version = "1", features = ["derive"]}

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -7,7 +7,9 @@
 extern crate pest;
 #[macro_use]
 extern crate pest_derive;
+extern crate indexmap;
 
+use indexmap::IndexMap;
 use pest::iterators::Pair;
 use pest::Parser;
 use std::boxed::Box;
@@ -49,7 +51,7 @@ pub struct Metadata {
     /// Other optional metadata contained in a [HashMap].
     pub ominous: HashMap<String, String>,
     /// Exact description of an [Ingredient] indexed by name.
-    pub ingredients: HashMap<String, Ingredient>,
+    pub ingredients: IndexMap<String, Ingredient>,
     /// Ingredient Specifier describing the mentioning of a [Ingredient]. The n-th mention of @
     /// in [Recipe::instruction] is the n-th [IngredientSpecifier] in this [Vec].
     pub ingredients_specifiers: Vec<IngredientSpecifier>,
@@ -155,7 +157,7 @@ pub fn parse(inp: &str) -> Result<Recipe, Box<dyn std::error::Error>> {
     let mut metadata = Metadata {
         servings: None,
         ominous: Default::default(),
-        ingredients: HashMap::new(),
+        ingredients: IndexMap::new(),
         ingredients_specifiers: vec![],
         cookware: vec![],
         timer: vec![],


### PR DESCRIPTION
The order of the ingredients change in the parse output each time a recipe is parsed.

This is because the ingredients are parsed into a HashMap, which doesn't retain any ordering information.

I feel like the ingredients should appear in the order that they are mentioned in the recipe (and shouldn't change without the recipe being changed, so I've switch the collection for ingredients to use the "IndexMap" crate, which retains insertion order.

